### PR TITLE
Make tag vars optional

### DIFF
--- a/tasks/linux.yml
+++ b/tasks/linux.yml
@@ -89,11 +89,31 @@
   changed_when: false
 
 - set_fact:
-    standard_tag_set:
-      - "tag:{{ tag_environment }}"
-      - "tag:{{ tag_type }}"
-      - "tag:{{ tag_chain }}"
-      - "tag:{{ tag_network }}"
+    standard_tag_set: []
+
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_environment }}'] }}"
+  when: tag_environment is defined
+
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_type }}'] }}"
+  when: tag_type is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_chain }}'] }}"
+  when: tag_chain is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_network }}'] }}"
+  when: tag_network is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_region }}'] }}"
+  when: tag_region is defined
+  
+- set_fact:
+    standard_tag_set: "{{ standard_tag_set + ['tag:{{ tag_cloud }}'] }}"
+  when: tag_cloud is defined
 - debug:
     var: standard_tag_set
     verbosity: 2


### PR DESCRIPTION
Currently the role requires the following vars populated
```
        tag_environment: "production"
        tag_type: "full"
        tag_chain: "fantom"
        tag_network: "mainnet"
        tag_region: "fra"
        tag_cloud: "oracle"
```
This makes the unusable on non-chain nodes

Updating so that it will use tag vars only if provided.